### PR TITLE
spec: tag totalTests with {.compiletime.}

### DIFF
--- a/balls/spec.nim
+++ b/balls/spec.nim
@@ -122,7 +122,7 @@ type
 
 var testCount {.compileTime.}: int                       # whatfer counting!
 
-proc totalTests*(): int =
+proc totalTests*(): int {.compileTime.} =
   ## reveal the value of the counter without exposing it
   testCount
 


### PR DESCRIPTION
nimskull has stricter compiletime requirements than Nim and requires
all procedures accessing compiletime variables to be compiletime-only.

Should compile with nimskull after: https://github.com/nim-works/nimskull/pull/1017